### PR TITLE
Add Docker container for static site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:alpine
+
+# Copy site content to the default nginx public directory
+COPY index.html /usr/share/nginx/html/index.html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# paraozzy.github.io
+# kushkoirala.github.io
+
+This repository hosts a static HTML page that can be served locally or in a container.
+
+## Containerized local preview
+
+You can serve the site with the open-source Docker Engine:
+
+1. Build the container image:
+   ```bash
+   docker build -t kushkoirala-site .
+   ```
+2. Run the container and map port 80 to your host (for example, port 8080):
+   ```bash
+   docker run --rm -p 8080:80 kushkoirala-site
+   ```
+3. Open `http://localhost:8080` in your browser to view the page.
+
+## Without Docker
+
+You can also preview the site with any static file server. For example, with Python:
+
+```bash
+python -m http.server
+```
+
+Then navigate to `http://localhost:8000`.


### PR DESCRIPTION
## Summary
- add an nginx-based Dockerfile to serve the static site
- ignore repository metadata from the Docker build context
- document how to build and run the container or preview locally

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_690ac72b8290832d8c7d64e0ea079149